### PR TITLE
Module.prepend vs class_evil?

### DIFF
--- a/app/controllers/spree/base_controller_decorator.rb
+++ b/app/controllers/spree/base_controller_decorator.rb
@@ -1,4 +1,4 @@
-module BaseControllerExtensions
+module Sprangular::BaseControllerDecorator
   def self.prepended(base)
     base.after_filter :set_csrf_cookie_for_ng
   end
@@ -16,5 +16,5 @@ end
 
 # TODO: should be just Spree::BaseController once base class is fixed here:
 # https://github.com/DynamoMTL/spree_chimpy/blob/master/app/controllers/spree/chimpy/subscribers_controller.rb#L1
-ApplicationController.send(:prepend, BaseControllerExtensions)
-Spree::BaseController.send(:prepend, BaseControllerExtensions)
+ApplicationController.send(:prepend, Sprangular::BaseControllerDecorator)
+Spree::BaseController.send(:prepend, Sprangular::BaseControllerDecorator)

--- a/app/controllers/spree/base_controller_decorator.rb
+++ b/app/controllers/spree/base_controller_decorator.rb
@@ -1,17 +1,20 @@
-# TODO: should be just Spree::BaseController once base class is fixed here:
-# https://github.com/DynamoMTL/spree_chimpy/blob/master/app/controllers/spree/chimpy/subscribers_controller.rb#L1
-[ApplicationController, Spree::BaseController].each do |klass|
-  klass.class_eval do
-    after_filter :set_csrf_cookie_for_ng
+module BaseControllerExtensions
+  def self.prepended(base)
+    base.after_filter :set_csrf_cookie_for_ng
+  end
 
   protected
 
-    def set_csrf_cookie_for_ng
-      cookies['XSRF-TOKEN'] = form_authenticity_token if protect_against_forgery?
-    end
+  def set_csrf_cookie_for_ng
+    cookies['XSRF-TOKEN'] = form_authenticity_token if protect_against_forgery?
+  end
 
-    def verified_request?
-      super || form_authenticity_token == request.headers['X-XSRF-TOKEN']
-    end
+  def verified_request?
+    super || form_authenticity_token == request.headers['X-XSRF-TOKEN']
   end
 end
+
+# TODO: should be just Spree::BaseController once base class is fixed here:
+# https://github.com/DynamoMTL/spree_chimpy/blob/master/app/controllers/spree/chimpy/subscribers_controller.rb#L1
+ApplicationController.send(:prepend, BaseControllerExtensions)
+Spree::BaseController.send(:prepend, BaseControllerExtensions)

--- a/app/models/spree/checkout_decorator.rb
+++ b/app/models/spree/checkout_decorator.rb
@@ -64,4 +64,4 @@ module Sprangular::OrderCheckoutDecorator
   end
 end
 
-Spree::Order.send :prepend, Sprangular::OrderCheckoutDecorator
+Spree::Order.send(:prepend, Sprangular::OrderCheckoutDecorator)

--- a/app/models/spree/checkout_decorator.rb
+++ b/app/models/spree/checkout_decorator.rb
@@ -1,75 +1,67 @@
 module Sprangular::OrderCheckoutDecorator
+  def update_from_params(params, permitted_params, request_env = {})
+    success = false
+    @updating_params = params
+    run_callbacks :updating_from_params do
+      attributes = @updating_params[:order] ? @updating_params[:order].permit(permitted_params).delete_if { |k,v| v.nil? } : {}
 
-  def self.included(base)
-    base.send(:prepend, InstanceMethods)
-  end
+      # Set existing card after setting permitted parameters because
+      # rails would slice parameters containg ruby objects, apparently
+      existing_card_id = @updating_params[:order] ? @updating_params[:order][:existing_card] : nil
 
-  module InstanceMethods
-    def update_from_params(params, permitted_params, request_env = {})
-      success = false
-      @updating_params = params
-      run_callbacks :updating_from_params do
-        attributes = @updating_params[:order] ? @updating_params[:order].permit(permitted_params).delete_if { |k,v| v.nil? } : {}
-
-        # Set existing card after setting permitted parameters because
-        # rails would slice parameters containg ruby objects, apparently
-        existing_card_id = @updating_params[:order] ? @updating_params[:order][:existing_card] : nil
-
-        if existing_card_id.present?
-          credit_card = ::Spree::CreditCard.find existing_card_id
-          if credit_card.user_id != self.user_id || credit_card.user_id.blank?
-            raise ::Spree::Core::GatewayError.new Spree.t(:invalid_credit_card)
-          end
-
-          credit_card.verification_value = params[:cvc_confirm] if params[:cvc_confirm].present?
-
-          attributes[:payments_attributes].first[:source] = credit_card
-          attributes[:payments_attributes].first[:payment_method_id] = credit_card.payment_method_id
-          attributes[:payments_attributes].first.delete :source_attributes
+      if existing_card_id.present?
+        credit_card = ::Spree::CreditCard.find existing_card_id
+        if credit_card.user_id != self.user_id || credit_card.user_id.blank?
+          raise ::Spree::Core::GatewayError.new Spree.t(:invalid_credit_card)
         end
 
-        if attributes[:payments_attributes]
-          attributes[:payments_attributes].first[:request_env] = request_env
-        end
+        credit_card.verification_value = params[:cvc_confirm] if params[:cvc_confirm].present?
 
-        if attributes[:payments_attributes] && attributes[:payments_attributes].first[:source_attributes].nil? && existing_card_id.nil?
-          # don't allow payments to be created until we're ready to confirm
-          attributes.delete :payments_attributes
-        end
-
-        # Adds Sprangular support to resuse an address
-        if attributes[:bill_address_attributes]
-          existing_billing_address = attributes[:bill_address_attributes][:id]
-
-          if existing_billing_address.present?
-            bill_address = ::Spree::Address.find(existing_billing_address)
-            self.bill_address = bill_address
-            attributes.delete :bill_address_attributes
-          end
-
-          existing_shipping_address = attributes[:ship_address_attributes][:id]
-
-          if existing_shipping_address.present?
-            ship_address = ::Spree::Address.find(existing_shipping_address)
-            self.ship_address = ship_address
-            attributes.delete :ship_address_attributes
-          end
-        end
-
-        success = self.update_attributes(attributes)
-        set_shipments_cost if self.shipments.any?
+        attributes[:payments_attributes].first[:source] = credit_card
+        attributes[:payments_attributes].first[:payment_method_id] = credit_card.payment_method_id
+        attributes[:payments_attributes].first.delete :source_attributes
       end
 
-      @updating_params = nil
-      success
+      if attributes[:payments_attributes]
+        attributes[:payments_attributes].first[:request_env] = request_env
+      end
+
+      if attributes[:payments_attributes] && attributes[:payments_attributes].first[:source_attributes].nil? && existing_card_id.nil?
+        # don't allow payments to be created until we're ready to confirm
+        attributes.delete :payments_attributes
+      end
+
+      # Adds Sprangular support to resuse an address
+      if attributes[:bill_address_attributes]
+        existing_billing_address = attributes[:bill_address_attributes][:id]
+
+        if existing_billing_address.present?
+          bill_address = ::Spree::Address.find(existing_billing_address)
+          self.bill_address = bill_address
+          attributes.delete :bill_address_attributes
+        end
+
+        existing_shipping_address = attributes[:ship_address_attributes][:id]
+
+        if existing_shipping_address.present?
+          ship_address = ::Spree::Address.find(existing_shipping_address)
+          self.ship_address = ship_address
+          attributes.delete :ship_address_attributes
+        end
+      end
+
+      success = self.update_attributes(attributes)
+      set_shipments_cost if self.shipments.any?
     end
 
-    # override the default method here to prevent invalid payments from being created
-    def assign_default_credit_card
-      true
-    end
+    @updating_params = nil
+    success
   end
 
+  # override the default method here to prevent invalid payments from being created
+  def assign_default_credit_card
+    true
+  end
 end
 
-Spree::Order.send :include, Sprangular::OrderCheckoutDecorator
+Spree::Order.send :prepend, Sprangular::OrderCheckoutDecorator

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,4 +1,4 @@
-Spree.user_class.class_eval do
+module UserExtensions
   def past_bill_addresses
     past_addresses :bill_address
   end
@@ -11,7 +11,7 @@ Spree.user_class.class_eval do
     orders.complete.order('updated_at DESC')
   end
 
-private
+  private
 
   def past_addresses(address_type)
     addresses = (past_orders_with_most_recent_first(address_type).map(&address_type) + [send(address_type)]).compact
@@ -25,3 +25,5 @@ private
     completed_orders.includes(address_type => [:state, :country])
   end
 end
+
+Spree.user_class.send(:prepend, UserExtensions)

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,4 +1,4 @@
-module UserExtensions
+module Sprangular::UserDecorator
   def past_bill_addresses
     past_addresses :bill_address
   end
@@ -26,4 +26,4 @@ module UserExtensions
   end
 end
 
-Spree.user_class.send(:prepend, UserExtensions)
+Spree.user_class.send(:prepend, Sprangular::UserDecorator)


### PR DESCRIPTION
Does Sprangular need to support MRI 1.9.3?

If not, would you be amenable to a PR converting the decoration mechanism over to `Module.prepend`, rather than .class_evil?