### PR TITLE
Removes call to OrderPopulator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby "2.0.0"
+ruby "2.1.5"
 
 source "https://rubygems.org"
 source "https://rails-assets.org"

--- a/app/controllers/sprangular/carts_controller.rb
+++ b/app/controllers/sprangular/carts_controller.rb
@@ -14,9 +14,11 @@ class Sprangular::CartsController < Sprangular::BaseController
     order = current_order(create_order_if_necessary: true)
     variant  = Spree::Variant.find(params[:variant_id])
     quantity = params[:quantity].to_i
+    options  = (params[:options] || {}).merge(currency: current_currency)
 
     if quantity.between?(1, 2_147_483_647)
       begin
+        line_item = order.contents.add(variant, quantity)
         order.ensure_updated_shipments
         @order = order.reload
         render 'spree/api/orders/show'

--- a/app/controllers/sprangular/carts_controller.rb
+++ b/app/controllers/sprangular/carts_controller.rb
@@ -14,11 +14,9 @@ class Sprangular::CartsController < Sprangular::BaseController
     order = current_order(create_order_if_necessary: true)
     variant  = Spree::Variant.find(params[:variant_id])
     quantity = params[:quantity].to_i
-    options  = (params[:options] || {}).merge(currency: current_currency)
 
     if quantity.between?(1, 2_147_483_647)
       begin
-        line_item = order.contents.add(variant, quantity)
         order.ensure_updated_shipments
         @order = order.reload
         render 'spree/api/orders/show'

--- a/app/controllers/sprangular/carts_controller.rb
+++ b/app/controllers/sprangular/carts_controller.rb
@@ -14,11 +14,10 @@ class Sprangular::CartsController < Sprangular::BaseController
     order = current_order(create_order_if_necessary: true)
     variant  = Spree::Variant.find(params[:variant_id])
     quantity = params[:quantity].to_i
-    options  = (params[:options] || {}).merge(currency: current_currency)
 
     if quantity.between?(1, 2_147_483_647)
       begin
-        line_item = order.contents.add(variant, quantity)
+        order.contents.add(variant, quantity)
         order.ensure_updated_shipments
         @order = order.reload
         render 'spree/api/orders/show'


### PR DESCRIPTION
[OrderPopulator will be deprecated in Spree 3.0](https://github.com/spree/spree/blob/2-4-stable/core/app/models/spree/order_populator.rb#L13)

This PR will replace OrderPopulator with OrderContents