### PR TITLE
Allow developers to customize num of products per page

### DIFF
--- a/app/assets/javascripts/sprangular/services/catalog.coffee
+++ b/app/assets/javascripts/sprangular/services/catalog.coffee
@@ -1,6 +1,6 @@
-Sprangular.service 'Catalog', ($http, $q, _, Status) ->
+Sprangular.service 'Catalog', ($http, $q, _, Status, Env) ->
   service =
-    pageSize: 8
+    pageSize: Env.config.product_page_size
 
     products: (search=null, page=1, options) ->
       options ||= {}

--- a/app/helpers/sprangular/application_helper.rb
+++ b/app/helpers/sprangular/application_helper.rb
@@ -29,7 +29,8 @@ module Sprangular
           default_country_id: config.default_country_id,
           facebook_app_id: ENV['FACEBOOK_APP_ID'],
           payment_methods: payment_methods,
-          image_sizes: Spree::Image.attachment_definitions[:attachment][:styles].keys
+          image_sizes: Spree::Image.attachment_definitions[:attachment][:styles].keys,
+          product_page_size: Spree::Config.products_per_page
         },
         templates: templates
       }


### PR DESCRIPTION
Sprangular will now return the number of products per page as defined by `Spree::Config.products_per_page`