### PR TITLE
Ensure the cache keys include locale, as names can be localized.

### DIFF
--- a/app/views/sprangular/taxonomies/index.rabl
+++ b/app/views/sprangular/taxonomies/index.rabl
@@ -1,4 +1,4 @@
 collection @taxonomies
-cache :all
+cache [I18n.locale, @taxonomies]
 
 extends "spree/api/taxonomies/show"

--- a/app/views/sprangular/taxons/show.v1.rabl
+++ b/app/views/sprangular/taxons/show.v1.rabl
@@ -1,5 +1,5 @@
 object @taxon
-cache @taxon
+cache [I18n.locale, @taxon]
 attributes *taxon_attributes
 
 node do |t|


### PR DESCRIPTION
This add basic support for spree-i18n.