### PR TITLE
Cache Countires api, as Spree i18n

### DIFF
--- a/app/views/sprangular/countries/index.rabl
+++ b/app/views/sprangular/countries/index.rabl
@@ -1,2 +1,3 @@
 collection @countries
+cache [I18n.locale, @countries]
 extends "spree/api/countries/show"


### PR DESCRIPTION
 as spree_i18n very slow at rendering translations names of countries.  This is a temp fix, until some performance increases are added up stream. 