### PR TITLE
Cache products only on Show page

### DIFF
--- a/app/assets/javascripts/sprangular/routes.coffee
+++ b/app/assets/javascripts/sprangular/routes.coffee
@@ -31,7 +31,7 @@ Sprangular.config ($routeProvider) ->
         product: (Status, Catalog, $route) ->
           slug = $route.current.params.id
 
-          Status.findCachedProduct(slug) || Catalog.find(slug)
+          Catalog.find(slug)
 
     .when '/t/:path*',
       controller: 'ProductListCtrl'

--- a/app/assets/javascripts/sprangular/routes.coffee
+++ b/app/assets/javascripts/sprangular/routes.coffee
@@ -31,7 +31,7 @@ Sprangular.config ($routeProvider) ->
         product: (Status, Catalog, $route) ->
           slug = $route.current.params.id
 
-          Catalog.find(slug)
+          Status.findCachedProduct(slug) || Catalog.find(slug)
 
     .when '/t/:path*',
       controller: 'ProductListCtrl'

--- a/app/assets/javascripts/sprangular/services/catalog.coffee
+++ b/app/assets/javascripts/sprangular/services/catalog.coffee
@@ -34,7 +34,7 @@ Sprangular.service 'Catalog', ($http, $q, _, Status, Env) ->
     find: (id) ->
       $http.get("/api/products/#{id}", class: Sprangular.Product)
         .then (response) ->
-          console.log response.data
+          console.log response
 
     getPaged: (page=1, params={}) ->
       $http.get("/api/products", ignoreLoadingIndicator: params.ignoreLoadingIndicator, params: {per_page: @pageSize, page: page, "q[name_or_description_cont]": params.search, "q[taxons_permalink_eq]": params.taxon})

--- a/app/assets/javascripts/sprangular/services/catalog.coffee
+++ b/app/assets/javascripts/sprangular/services/catalog.coffee
@@ -35,6 +35,7 @@ Sprangular.service 'Catalog', ($http, $q, _, Status, Env) ->
       $http.get("/api/products/#{id}", class: Sprangular.Product)
         .then (response) ->
           Status.cacheProduct(response)
+          response
 
     getPaged: (page=1, params={}) ->
       $http.get("/api/products", ignoreLoadingIndicator: params.ignoreLoadingIndicator, params: {per_page: @pageSize, page: page, "q[name_or_description_cont]": params.search, "q[taxons_permalink_eq]": params.taxon})

--- a/app/assets/javascripts/sprangular/services/catalog.coffee
+++ b/app/assets/javascripts/sprangular/services/catalog.coffee
@@ -33,6 +33,10 @@ Sprangular.service 'Catalog', ($http, $q, _, Status, Env) ->
 
     find: (id) ->
       $http.get("/api/products/#{id}", class: Sprangular.Product)
+        .then (response) ->
+          console.log response.data
+          product = Sprangular.extend(response.data, Sprangular.Product)
+          Status.cacheProduct(product)
 
     getPaged: (page=1, params={}) ->
       $http.get("/api/products", ignoreLoadingIndicator: params.ignoreLoadingIndicator, params: {per_page: @pageSize, page: page, "q[name_or_description_cont]": params.search, "q[taxons_permalink_eq]": params.taxon})

--- a/app/assets/javascripts/sprangular/services/catalog.coffee
+++ b/app/assets/javascripts/sprangular/services/catalog.coffee
@@ -34,7 +34,7 @@ Sprangular.service 'Catalog', ($http, $q, _, Status, Env) ->
     find: (id) ->
       $http.get("/api/products/#{id}", class: Sprangular.Product)
         .then (response) ->
-          console.log response
+          Status.cacheProduct response
 
     getPaged: (page=1, params={}) ->
       $http.get("/api/products", ignoreLoadingIndicator: params.ignoreLoadingIndicator, params: {per_page: @pageSize, page: page, "q[name_or_description_cont]": params.search, "q[taxons_permalink_eq]": params.taxon})

--- a/app/assets/javascripts/sprangular/services/catalog.coffee
+++ b/app/assets/javascripts/sprangular/services/catalog.coffee
@@ -34,7 +34,7 @@ Sprangular.service 'Catalog', ($http, $q, _, Status, Env) ->
     find: (id) ->
       $http.get("/api/products/#{id}", class: Sprangular.Product)
         .then (response) ->
-          Status.cacheProduct response
+          Status.cacheProduct(response)
 
     getPaged: (page=1, params={}) ->
       $http.get("/api/products", ignoreLoadingIndicator: params.ignoreLoadingIndicator, params: {per_page: @pageSize, page: page, "q[name_or_description_cont]": params.search, "q[taxons_permalink_eq]": params.taxon})

--- a/app/assets/javascripts/sprangular/services/catalog.coffee
+++ b/app/assets/javascripts/sprangular/services/catalog.coffee
@@ -43,7 +43,7 @@ Sprangular.service 'Catalog', ($http, $q, _, Status, Env) ->
           list.totalCount = data.meta.total_count
           list.totalPages = data.meta.pages
           list.page = data.meta.current_page
-          Status.cacheProducts(list)
+          # Status.cacheProducts(list)
           list
 
   service

--- a/app/assets/javascripts/sprangular/services/catalog.coffee
+++ b/app/assets/javascripts/sprangular/services/catalog.coffee
@@ -35,8 +35,6 @@ Sprangular.service 'Catalog', ($http, $q, _, Status, Env) ->
       $http.get("/api/products/#{id}", class: Sprangular.Product)
         .then (response) ->
           console.log response.data
-          product = Sprangular.extend(response.data, Sprangular.Product)
-          Status.cacheProduct(product)
 
     getPaged: (page=1, params={}) ->
       $http.get("/api/products", ignoreLoadingIndicator: params.ignoreLoadingIndicator, params: {per_page: @pageSize, page: page, "q[name_or_description_cont]": params.search, "q[taxons_permalink_eq]": params.taxon})
@@ -47,7 +45,6 @@ Sprangular.service 'Catalog', ($http, $q, _, Status, Env) ->
           list.totalCount = data.meta.total_count
           list.totalPages = data.meta.pages
           list.page = data.meta.current_page
-          # Status.cacheProducts(list)
           list
 
   service

--- a/app/assets/javascripts/sprangular/services/status.coffee
+++ b/app/assets/javascripts/sprangular/services/status.coffee
@@ -13,6 +13,9 @@ Sprangular.service "Status", ($rootScope, $translate) ->
     isLoading: ->
       @httpLoading || @routeChanging
 
+    cacheProduct: (product) ->
+      status.cacheProducts.push product
+
     cacheProducts: (list) ->
       status.cachedProducts = status.cachedProducts.concat(list)
 

--- a/app/assets/javascripts/sprangular/services/status.coffee
+++ b/app/assets/javascripts/sprangular/services/status.coffee
@@ -20,6 +20,7 @@ Sprangular.service "Status", ($rootScope, $translate) ->
       status.cachedProducts = status.cachedProducts.concat(list)
 
     findCachedProduct: (slug) ->
+      console.log status.cachedProducts
       _.find status.cachedProducts, (product) ->
         product.slug == slug
 

--- a/app/assets/javascripts/sprangular/services/status.coffee
+++ b/app/assets/javascripts/sprangular/services/status.coffee
@@ -20,7 +20,6 @@ Sprangular.service "Status", ($rootScope, $translate) ->
       status.cachedProducts = status.cachedProducts.concat(list)
 
     findCachedProduct: (slug) ->
-      console.log status.cachedProducts
       _.find status.cachedProducts, (product) ->
         product.slug == slug
 

--- a/app/assets/javascripts/sprangular/services/status.coffee
+++ b/app/assets/javascripts/sprangular/services/status.coffee
@@ -14,7 +14,7 @@ Sprangular.service "Status", ($rootScope, $translate) ->
       @httpLoading || @routeChanging
 
     cacheProduct: (product) ->
-      status.cacheProducts.push product
+      status.cachedProducts.push(product)
 
     cacheProducts: (list) ->
       status.cachedProducts = status.cachedProducts.concat(list)


### PR DESCRIPTION
This allows the product listing to have the minimal amount of informations. All the information needed for product show page is only fetched on the product show page.