### PR TITLE
Allows sprangular to find pages by slug

### DIFF
--- a/app/assets/javascripts/sprangular/module.coffee
+++ b/app/assets/javascripts/sprangular/module.coffee
@@ -106,5 +106,5 @@ Sprangular.run (
 
   $rootScope.$on '$routeChangeError', (event, current, previous, rejection) ->
     Status.routeChanging = false
-    alert "Error changing route. See console for details."
     $log.info "Error changing route", rejection
+    $location.path('/404')

--- a/app/assets/javascripts/sprangular/routes.coffee
+++ b/app/assets/javascripts/sprangular/routes.coffee
@@ -86,5 +86,16 @@ Sprangular.config ($routeProvider) ->
         order: (Orders, $route) ->
           Orders.find($route.current.params.number)
 
+    .when '/404',
+      templateUrl: '404.html'
+
+    .when '/:slug',
+      controller: 'PageShowCtrl'
+      templateUrl: 'pages/show.html'
+      resolve:
+        page: (StaticContent, $route)->
+          slug = $route.current.params.slug
+          StaticContent.find(slug)
+
     .otherwise
       templateUrl: '404.html'


### PR DESCRIPTION
For use with sprangular_static_content. This branch will
allow pages to be found by slug, without the /pages/ namespace.

@joshnuss - Let me know what you think. Ideally, we could conditionally define routes if the StaticContent module is defined. 

Additionally, I think the default route change should result in a 404 and not an alert dialogue. This PR has that change as well. 