### PR TITLE
Fixes issue with cloud hosted assets

### DIFF
--- a/app/helpers/sprangular/application_helper.rb
+++ b/app/helpers/sprangular/application_helper.rb
@@ -46,9 +46,9 @@ module Sprangular
             .assets.each_logical_path
             .select { |file| file.end_with?('html') }
             .map do |file|
-              path = digest_assets? ? File.join('/assets', Rails.application.assets[file].digest_path) : asset_path(file)
+              path = digest_assets? ? File.join('/assets', Rails.application.assets[file].digest_path) : file
 
-              [file, path]
+              [file, asset_path(path)]
             end
         ]
       end


### PR DESCRIPTION
This fixes templates paths to honour asset_host (eg cloudfront) when configured.

@bryanmtl this should make templates way faster in production.

the `templates` dictionary in the layout used to look like this:

```json
"templates":
  {"static/about.html":"/assets/static/about.html"}
```

it will now look like this (when asset_host configured)

```json
"templates":
  {"static/about.html":"https://xyz123.cloudfront.net/assets/static/about.html"}
```
