### PR TITLE
Splits Delivery and Payment Checkout Steps

### DIFF
--- a/app/assets/javascripts/sprangular/controllers/checkout/delivery.coffee
+++ b/app/assets/javascripts/sprangular/controllers/checkout/delivery.coffee
@@ -1,0 +1,28 @@
+Sprangular.controller 'CheckoutDeliveryCtrl', ($scope, Account, Cart, Checkout) ->
+  $scope.order = Cart.current
+  $scope.processing = false
+  $scope.user = Account.user
+  $scope.submitted = false
+
+  $scope.$watch 'order.state', (state) ->
+    $scope.done = _.include ['payment', 'confirm'], state
+    $scope.active = state is 'delivery'
+
+  $scope.edit = ->
+    order = $scope.order
+    creditCard = order.creditCard
+
+    order.creditCard = new Sprangular.CreditCard unless creditCard.id?
+    order.state = 'delivery'
+
+  $scope.advance = ->
+    order = $scope.order
+    $scope.submitted = true
+    $scope.processing = true
+
+    Checkout.setDelivery()
+      .then ->
+          $scope.processing = false
+          $scope.submitted = false
+        , ->
+          $scope.processing = false

--- a/app/assets/javascripts/sprangular/controllers/checkout/payment.coffee
+++ b/app/assets/javascripts/sprangular/controllers/checkout/payment.coffee
@@ -1,19 +1,19 @@
-Sprangular.controller 'CheckoutDeliveryAndPaymentCtrl', ($scope, Account, Cart, Checkout) ->
+Sprangular.controller 'CheckoutPaymentCtrl', ($scope, Account, Cart, Checkout) ->
   $scope.order = Cart.current
   $scope.processing = false
   $scope.user = Account.user
   $scope.submitted = false
 
   $scope.$watch 'order.state', (state) ->
-    $scope.done = state == 'confirm'
-    $scope.active = _.contains(['delivery', 'payment'], state)
+    $scope.done = state is 'confirm'
+    $scope.active = state is 'payment'
 
   $scope.edit = ->
     order = $scope.order
     creditCard = order.creditCard
 
     order.creditCard = new Sprangular.CreditCard unless creditCard.id?
-    order.state = 'delivery'
+    order.state = 'payment'
 
   $scope.advance = ->
     order = $scope.order
@@ -23,9 +23,10 @@ Sprangular.controller 'CheckoutDeliveryAndPaymentCtrl', ($scope, Account, Cart, 
 
     $scope.processing = true
 
-    Checkout.setDeliveryAndPayment()
+    Checkout.setPayment()
       .then ->
           $scope.processing = false
           $scope.submitted = false
         , ->
           $scope.processing = false
+

--- a/app/assets/javascripts/sprangular/directives/shippingRatesSelection.coffee
+++ b/app/assets/javascripts/sprangular/directives/shippingRatesSelection.coffee
@@ -2,6 +2,7 @@ Sprangular.directive 'shippingRateSelection', ->
   restrict: 'E'
   templateUrl: 'shipping/rates.html'
   scope:
+    onSelection: '&'
     order: '='
     disabled: '='
 

--- a/app/assets/javascripts/sprangular/services/checkout.coffee
+++ b/app/assets/javascripts/sprangular/services/checkout.coffee
@@ -40,14 +40,22 @@ Sprangular.service "Checkout", ($http, $q, _, Env, Account, Cart) ->
 
       @put(params, ignoreLoadingIndicator: true)
 
-    setDeliveryAndPayment: ->
+    setDelivery: ->
+      order = Cart.current
+
+      params =
+        'order[shipments_attributes][][id]': order.shipment.id
+        'order[shipments_attributes][][selected_shipping_rate_id]': order.shippingRate.id
+        'state': 'delivery'
+
+      @put(params, ignoreLoadingIndicator: true)
+
+    setPayment: ->
       order = Cart.current
       card  = order.creditCard
       paymentMethodId = @_findPaymentMethodId()
 
       params =
-        'order[shipments_attributes][][id]': order.shipment.id
-        'order[shipments_attributes][][selected_shipping_rate_id]': order.shippingRate.id
         'order[payments_attributes][][payment_method_id]': paymentMethodId
         'order[existing_card]': ''
         'state': 'payment'

--- a/app/assets/stylesheets/sprangular/_base.scss
+++ b/app/assets/stylesheets/sprangular/_base.scss
@@ -215,6 +215,7 @@ section.gallery {
 #checkout-details {
   .step {
     opacity: 0.6;
+    position: relative;
 
     &.active, &.review {
       opacity: 1;

--- a/app/assets/templates/checkout/delivery.html.slim
+++ b/app/assets/templates/checkout/delivery.html.slim
@@ -1,0 +1,9 @@
+section.step.delivery(ng-controller='CheckoutDeliveryCtrl' ng-class="{active: active, done: done, loading: processing}")
+  .edit(ng-show='done' ng-click='edit()')
+    span.fa.fa-pencil
+
+  section#delivery
+    h2
+      | {{ :: 'checkout.delivery_options' | translate}}
+
+    shipping-rate-selection(order='order' disabled='!active || processing' on-selection='advance()')

--- a/app/assets/templates/checkout/index.html.slim
+++ b/app/assets/templates/checkout/index.html.slim
@@ -17,7 +17,8 @@
       ng-include(src="'checkout/addresses.html'")
 
     .col-md-4.col-xs-12
-      ng-include(src="'checkout/delivery_and_payment.html'")
+      ng-include(src="'checkout/delivery.html'")
+      ng-include(src="'checkout/payment.html'")
 
     .col-md-4.col-xs-12
       ng-include(src="'checkout/review.html'")

--- a/app/assets/templates/checkout/payment.html.slim
+++ b/app/assets/templates/checkout/payment.html.slim
@@ -1,12 +1,6 @@
-section.step.delivery-and-payment(ng-controller='CheckoutDeliveryAndPaymentCtrl' ng-class="{active: active, done: done, loading: processing}")
+section.step.payment(ng-controller='CheckoutPaymentCtrl' ng-class="{active: active, done: done, loading: processing}")
   .edit(ng-show='done' ng-click='edit()')
     span.fa.fa-pencil
-
-  section#delivery
-    h2
-      | {{ :: 'checkout.delivery_options' | translate}}
-
-    shipping-rate-selection(order='order' disabled='!active || processing')
 
   section#credit-card
     h2

--- a/app/assets/templates/shipping/rates.html.slim
+++ b/app/assets/templates/shipping/rates.html.slim
@@ -14,6 +14,6 @@
     ul.list-unstyled(ng-show='order.shippingRates.length > 0')
       li(ng-repeat='shippingRate in order.shippingRates')
         label
-          input(type='radio' ng-model='order.shippingRate' ng-value='shippingRate' ng-disabled='disabled')
+          input(type='radio' ng-model='order.shippingRate' ng-value='shippingRate' ng-disabled='disabled' ng-click='onSelection()')
           span
             | &nbsp;{{shippingRate.name}} {{shippingRate.cost | currency : currencySymbol}}


### PR DESCRIPTION
Several Spree modules rely on certain checkout-transition callbacks being triggered during checkout. As a result of smushing delivery and payment steps together, Sprangular inadvertently skips these callbacks, which causes some weird behaviours. See #168 for additional details.

This commit attempts to correct this issue by performing the two checkout steps discretely.