### PR TITLE
Support for Asset Hosting

### DIFF
--- a/app/assets/javascripts/sprangular/module.coffee
+++ b/app/assets/javascripts/sprangular/module.coffee
@@ -57,6 +57,13 @@ Sprangular.config [
     $translateProvider.use(Env.locale)
 ]
 
+Sprangular.config ["$sceDelegateProvider", "Env", ($sceDelegateProvider, Env) ->
+  whitelist = ['self']
+  whitelist.push "#{Env.asset_host}/**" if Env.asset_host?
+
+  $sceDelegateProvider.resourceUrlWhitelist(whitelist)
+]
+
 Sprangular.run (
   $rootScope,
   $location,

--- a/app/helpers/sprangular/application_helper.rb
+++ b/app/helpers/sprangular/application_helper.rb
@@ -16,7 +16,8 @@ module Sprangular
         locale: I18n.locale,
         currency: Money::Currency.table[current_currency.downcase.to_sym],
         translations: current_translations,
-        templates: template_paths
+        templates: template_paths,
+        asset_host: compute_asset_host
       }
     end
 
@@ -40,17 +41,9 @@ module Sprangular
 
     def template_paths
       Rails.cache.fetch('template_paths') do
-        Hash[
-          Rails
-            .application
-            .assets.each_logical_path
-            .select { |file| file.end_with?('html') }
-            .map do |file|
-              path = digest_assets? ? File.join('/assets', Rails.application.assets[file].digest_path) : file
+        logical_paths = assets.each_logical_path("*.html")
 
-              [file, asset_path(path)]
-            end
-        ]
+        Hash[logical_paths.map { |file| [file, asset_path(file)] }]
       end
     end
 
@@ -86,31 +79,26 @@ module Sprangular
     end
 
     def cached_templates_for_dir(files, dir)
-      root = Sprangular::Engine.root
+      logical_paths = templates.each_logical_path("#{dir}/**")
 
-      files = Dir[root + "app/assets/templates/#{dir}/**"].inject(files) do |hash, path|
-        asset_path = asset_path path.gsub(root.to_s + "/app/assets/templates/", "")
-        local_path = "app/assets/templates/" + asset_path
-
-        hash[asset_path.gsub(/.slim$/, '')] = Tilt.new(path).render.html_safe if !File.exists?(local_path)
-
-        hash
-      end
-
-      Dir["app/assets/templates/#{dir}/**"].inject(files) do |hash, path|
-        sprockets_path = path.gsub("app/assets/templates/", "")
-
-        asset_path = asset_path(sprockets_path).
-          gsub(/^\/app\/assets\/templates/, '/assets').
-          gsub(/.slim$/, '')
-
-        hash[asset_path] = Rails.application.assets.find_asset(sprockets_path).body.html_safe
+      logical_paths.inject(files) do |hash, path|
+        hash[asset_path(path)] = assets[path].body.html_safe
         hash
       end
     end
 
     def serialize(object, serializer)
       serializer.new(object, root: false).to_json
+    end
+
+    private
+
+    def templates
+      @_templates ||= Sprockets::Environment.new.tap do |env|
+        [Rails.root, Sprangular::Engine.root].each do |root|
+          env.append_path root.join("app/assets/templates/")
+        end
+      end
     end
   end
 end

--- a/app/views/sprangular/shared/_templates.html.slim
+++ b/app/views/sprangular/shared/_templates.html.slim
@@ -1,3 +1,2 @@
 - cached_templates.each do |full_path, html|
-  - relative_path = URI(full_path).path.gsub(%r{^/assets/}, '')
-  script(type="text/ng-template" id=asset_path(relative_path))= html
+  script(type="text/ng-template" id=full_path)= html


### PR DESCRIPTION
The template-caching implementation doesn't work with asset-hosting or, indeed, even with custom `asset.prefix` values. This is due to the amount of direct asset-path manipulation in the `#template_paths` and `#cached_templates_for_dir` helper methods.

I've taken a crack at overhauling these methods to use only the Sprockets API, seen here.

There's also an Angular component to working well with asset-hosts: whitelisting the asset-host URL(s) in the $sceDelegate. It would be preferable if this didn't have to be configured on a store-by-store basis. Here's the code I had to add to my app's `host.coffee` to get asset-hosted URLs to work:

```ruby
HostApp.config ["$sceDelegateProvider", ($sceDelegateProvider) ->
  $sceDelegateProvider.resourceUrlWhitelist([
    # Allow same origin resource loads.
    'self',
    # Allow loading from our assets domain.  Notice the difference between * and **.
    'https://<%= ENV['FOG_DIRECTORY'] %>.s3.amazonaws.com/**'
  ])
]
```

The ERB interpolation is pretty gross. Any ideas on configuring that more elegantly/automatically?
