### PR TITLE
Fixes the Sprangular.CreditCard.TYPE_NAMES Mapping

### DIFF
--- a/app/assets/javascripts/sprangular/models/creditCard.coffee
+++ b/app/assets/javascripts/sprangular/models/creditCard.coffee
@@ -5,6 +5,7 @@ class Sprangular.CreditCard
     master: 'MasterCard'
     visa: 'Visa'
     amex: 'American Express'
+    american_express: 'American Express'
     discover: 'Discover'
     dinersclub: 'Diners Club'
     jcb: 'JCB'


### PR DESCRIPTION
The `type` property of American Express credit-card representations emitted by the Spree API is 'american_express', not 'amex'.