### PR TITLE
Login Logout Route Fixed

### DIFF
--- a/app/assets/javascripts/sprangular/services/account.coffee
+++ b/app/assets/javascripts/sprangular/services/account.coffee
@@ -64,7 +64,7 @@ Sprangular.service "Account", ($http, _, $q, Cart, Flash, $translate) ->
       params =
         'spree_user[email]': data.email,
         'spree_user[password]': data.password
-      $http.post('/spree/login.json', $.param(params))
+      $http.post('/login.json', $.param(params))
         .success (data) ->
           service.populateAccount(data)
           Flash.success 'app.signed_in'

--- a/app/assets/javascripts/sprangular/services/account.coffee
+++ b/app/assets/javascripts/sprangular/services/account.coffee
@@ -72,11 +72,12 @@ Sprangular.service "Account", ($http, _, $q, Cart, Flash, $translate) ->
           Flash.error 'app.signin_failed'
 
     logout: ->
-      $http.get('/spree/logout')
+      $http.get('/logout')
         .success (data) ->
           service.isLogged = false
           service.clear()
           Cart.init()
+          window.location = '/'
 
     signup: (data) ->
       params =


### PR DESCRIPTION
The login route should be set to the bare /login route. Currently the
app doesn't deliver a /spree/login route due to it using Sprangular lite.