### PR TITLE
Update $routeChangeError message

### DIFF
--- a/app/assets/javascripts/sprangular/module.coffee
+++ b/app/assets/javascripts/sprangular/module.coffee
@@ -11,7 +11,7 @@ window.Sprangular = angular.module('Sprangular', [
     paymentMethods = Env.config.payment_methods
 
     if paymentMethods.length == 0
-      alert 'Gateway is not configured in Spree...'
+      console.log 'Gateway is not configured in Spree...'
 
 Sprangular.startupData = {}
 
@@ -113,5 +113,6 @@ Sprangular.run (
 
   $rootScope.$on '$routeChangeError', (event, current, previous, rejection) ->
     Status.routeChanging = false
-    alert "Error changing route. See console for details."
+    console.log "Error changing route."
     $log.info "Error changing route", rejection
+    $location.path "/404"

--- a/app/assets/javascripts/sprangular/module.coffee
+++ b/app/assets/javascripts/sprangular/module.coffee
@@ -11,7 +11,7 @@ window.Sprangular = angular.module('Sprangular', [
     paymentMethods = Env.config.payment_methods
 
     if paymentMethods.length == 0
-      console.log 'Gateway is not configured in Spree...'
+      $log.info 'Gateway is not configured in Spree...'
 
 Sprangular.startupData = {}
 
@@ -113,5 +113,5 @@ Sprangular.run (
 
   $rootScope.$on '$routeChangeError', (event, current, previous, rejection) ->
     Status.routeChanging = false
-    console.log "Error changing route", rejection
+    $log.info "Error changing route", rejection
     $location.path "/404"

--- a/app/assets/javascripts/sprangular/module.coffee
+++ b/app/assets/javascripts/sprangular/module.coffee
@@ -11,7 +11,7 @@ window.Sprangular = angular.module('Sprangular', [
     paymentMethods = Env.config.payment_methods
 
     if paymentMethods.length == 0
-      console.log 'Gateway is not configured in Spree...'
+      $log.info 'Gateway is not configured in Spree...'
 
 Sprangular.startupData = {}
 
@@ -113,6 +113,5 @@ Sprangular.run (
 
   $rootScope.$on '$routeChangeError', (event, current, previous, rejection) ->
     Status.routeChanging = false
-    console.log "Error changing route."
     $log.info "Error changing route", rejection
     $location.path "/404"

--- a/app/assets/javascripts/sprangular/module.coffee
+++ b/app/assets/javascripts/sprangular/module.coffee
@@ -11,7 +11,7 @@ window.Sprangular = angular.module('Sprangular', [
     paymentMethods = Env.config.payment_methods
 
     if paymentMethods.length == 0
-      $log.info 'Gateway is not configured in Spree...'
+      console.log 'Gateway is not configured in Spree...'
 
 Sprangular.startupData = {}
 
@@ -113,5 +113,5 @@ Sprangular.run (
 
   $rootScope.$on '$routeChangeError', (event, current, previous, rejection) ->
     Status.routeChanging = false
-    $log.info "Error changing route", rejection
+    console.log "Error changing route", rejection
     $location.path "/404"


### PR DESCRIPTION
The current UX is to alert the user with a popup (an `alert`) when a `$routeChangeError` occurs, which is a rather aggressive and confusing to the user. 

This PR proposes to change the `alert` to a `console.log` and redirect to a 404 page.
