### PR TITLE
Update routeChangeError message

### DIFF
--- a/app/assets/javascripts/sprangular/module.coffee
+++ b/app/assets/javascripts/sprangular/module.coffee
@@ -11,7 +11,7 @@ window.Sprangular = angular.module('Sprangular', [
     paymentMethods = Env.config.payment_methods
 
     if paymentMethods.length == 0
-      alert 'Gateway is not configured in Spree...'
+      $log.info 'Gateway is not configured in Spree...'
 
 Sprangular.startupData = {}
 
@@ -113,5 +113,5 @@ Sprangular.run (
 
   $rootScope.$on '$routeChangeError', (event, current, previous, rejection) ->
     Status.routeChanging = false
-    alert "Error changing route. See console for details."
     $log.info "Error changing route", rejection
+    $location.path "/404"

--- a/app/assets/javascripts/sprangular/module.coffee
+++ b/app/assets/javascripts/sprangular/module.coffee
@@ -7,7 +7,7 @@ window.Sprangular = angular.module('Sprangular', [
   'mgcrea.ngStrap'
   'angularytics'
   'pascalprecht.translate'
-]).run (Env) ->
+]).run (Env, $log) ->
     paymentMethods = Env.config.payment_methods
 
     if paymentMethods.length == 0


### PR DESCRIPTION
The current UX is to return the user with a popup when the data fails to load and there is a routeChangeError. This is a bit aggressive and confusing to the user. 

I'm proposing to change this to a log and redirect to 404 as seen in the PR that was merged to `master` here: https://github.com/sprangular/sprangular/pull/198

Since the project is following the latest commit on `discrete-delivery-and-payment`, I'm proposing updating this branch specifically for the least amount of friction.