### PR TITLE
Ensure log gets injected in module.

### DIFF
--- a/app/assets/javascripts/sprangular/module.coffee
+++ b/app/assets/javascripts/sprangular/module.coffee
@@ -7,7 +7,7 @@ window.Sprangular = angular.module('Sprangular', [
   'mgcrea.ngStrap'
   'angularytics'
   'pascalprecht.translate'
-]).run (Env) ->
+]).run (Env, $log) ->
     paymentMethods = Env.config.payment_methods
 
     if paymentMethods.length == 0


### PR DESCRIPTION
Since we replaced the `alert` with a `$log` if no payment methods have been configured in Spree, we'll need to ensure that the `$log` is injected in this module in order for it to run smoothly.

This PR proposes a hotfix for this PR https://github.com/sprangular/sprangular/pull/199